### PR TITLE
Dockerize mkdocs development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3
+WORKDIR docs
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+CMD mkdocs serve -a 0.0.0.0:8000
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  docs:
+    build:
+      context: .
+    volumes:
+      - ./:/docs
+    ports:
+      - 8000:8000
+    

--- a/docs/edit-docs.md
+++ b/docs/edit-docs.md
@@ -74,7 +74,14 @@ This is only necessary if you need to see how the docs are specifically rendered
 
 [See above](#clone-the-repo)
 
-### Set up a python virtual environment
+### Option 1: Docker
+
+1. Download [Docker](https://www.docker.com/get-started), which should include Docker Compose on most machines.
+2. Run `docker-compose up` inside the project directory.
+3. The mkdocs server will start up, and can be accessed at `localhost:8000'. Any changes made to the docs will automatically update the page. 
+
+### Option 2: Setup Python Environment  
+#### Set up a python virtual environment
 
 _This step is optional but recommended._
 
@@ -89,12 +96,12 @@ source .venv/bin/activate
 
 You are now "in" a python virtual environment. You will leave the environment whenever you exit your terminal session, or when you run `deactivate`. Now, running `which python` should return a path in your `.venv/lib` folder, rather than a global install location like `/usr/bin`. 
 
-### Install dependencies
+#### Install dependencies
 ``` bash
 pip install -r requirements.txt
 ```
 
-### Run the development server
+#### Run the development server
 ``` bash
 mkdocs serve
 ```

--- a/docs/edit-docs.md
+++ b/docs/edit-docs.md
@@ -78,7 +78,7 @@ This is only necessary if you need to see how the docs are specifically rendered
 
 1. Download [Docker](https://www.docker.com/get-started), which should include Docker Compose on most machines.
 2. Run `docker-compose up` inside the project directory.
-3. The mkdocs server will start up, and can be accessed at `localhost:8000'. Any changes made to the docs will automatically update the page. 
+3. The mkdocs server will start up, and can be accessed at `localhost:8000`. Any changes made to the docs will automatically update the page. 
 
 ### Option 2: Setup Python Environment  
 #### Set up a python virtual environment


### PR DESCRIPTION
I find it easier to develop using a Docker container, so I'm adding that as an option here. Running `docker-compose up` will start the mkdocs server on your local machine.