### PR TITLE
Fixes favicon

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -8,6 +8,7 @@
   <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
   <meta http-equiv="pragma" content="no-cache" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="{{ config.theme.favicon | url }}" />
 
   <link rel="canonical" href="{{ page.canonical_url | default(page.abs_url) }}">
 


### PR DESCRIPTION
mkdocs-material defines `{% block site_meta %}` in [base.html](https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/base.html), but we override that block [here](https://github.com/phillycommunitywireless/docs/blob/ce3f07640408616ffcc24a96d98b79d43258d363/overrides/main.html#L3).

```
{% block site_meta %}
...
      <!-- Favicon -->
      <link rel="icon" href="{{ config.theme.favicon | url }}" />
```

Adding this line back fixes the favicon 404 and causes it to appear as expected.