### PR TITLE
fix 404 page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:3.10
 
 WORKDIR /srv
-COPY requirements.txt .
-COPY mkdocs.yml .
+COPY . .
 RUN pip install -r requirements.txt
 
 CMD mkdocs serve -a 0.0.0.0:8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.10
 
 WORKDIR /srv
 COPY requirements.txt .
+COPY mkdocs.yml .
 RUN pip install -r requirements.txt
 
 CMD mkdocs serve -a 0.0.0.0:8000

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Philly Community Wireless Docs
-site_url: https://docs.phillycommunitywireless.org
+site_url: https://docs.phillycommunitywireless.org/en/latest/
 
 theme:
   name: material


### PR DESCRIPTION
add /en/latest to handle readthedocs lang switching to fix bad css serving on live 

<img width="775" height="1570" alt="Image" src="https://github.com/user-attachments/assets/c043e396-22d4-4041-ad8f-576bdb95d9ac" />

moot since Esp. docs are currently disabled but fixes 404 page. will need to be revisited when Spanish docs are re-enabled 

